### PR TITLE
change container_id to container

### DIFF
--- a/documentation/integration.md
+++ b/documentation/integration.md
@@ -61,7 +61,7 @@ window.tvWidget = new TradingView.widget({
     symbol: 'Bitfinex:BTC/USD', // default symbol
     interval: '1D', // default interval
     fullscreen: true, // displays the chart in the fullscreen mode
-    container_id: 'tv_chart_container',
+    container: 'tv_chart_container',
     datafeed: Datafeed,
     library_path: '../charting_library_clonned_data/charting_library/',
 });


### PR DESCRIPTION
**console warning:**
`container_id` is now deprecated. Please use `container` instead to either still pass a string or an `HTMLElement`.