### PR TITLE
CL-1406: Removing full_name from symbol

### DIFF
--- a/src/datafeed.js
+++ b/src/datafeed.js
@@ -50,6 +50,7 @@ async function getAllSymbols() {
 				const symbol = generateSymbol(exchange.value, leftPairPart, rightPairPart);
 				return {
 					symbol: symbol.short,
+					ticker: symbol.short,
 					description: symbol.short,
 					exchange: exchange.value,
 					type: 'crypto',
@@ -77,7 +78,7 @@ export default {
 		const symbols = await getAllSymbols();
 		const newSymbols = symbols.filter(symbol => {
 			const isExchangeValid = exchange === '' || symbol.exchange === exchange;
-			const fullName = `${symbol.exchange}:${symbol.symbol}`;
+			const fullName = `${symbol.exchange}:${symbol.ticker}`;
 			const isFullSymbolContainsInput = fullName
 				.toLowerCase()
 				.indexOf(userInput.toLowerCase()) !== -1;
@@ -96,9 +97,9 @@ export default {
 		const symbols = await getAllSymbols();
 		const symbolItem = symbols.find(({
 			exchange,
-			symbol
+			ticker
 		}) => {
-			const fullName = `${exchange}:${symbol}`;
+			const fullName = `${exchange}:${ticker}`;
 			return fullName === symbolName
 		});
 		if (!symbolItem) {
@@ -108,7 +109,7 @@ export default {
 		}
 		// Symbol information object
 		const symbolInfo = {
-			ticker: symbolItem.symbol,
+			ticker: symbolItem.ticker,
 			name: symbolItem.symbol,
 			description: symbolItem.description,
 			type: symbolItem.type,

--- a/src/datafeed.js
+++ b/src/datafeed.js
@@ -96,12 +96,8 @@ export default {
 		console.log('[resolveSymbol]: Method call', symbolName);
 		const symbols = await getAllSymbols();
 		const symbolItem = symbols.find(({
-			exchange,
 			ticker
-		}) => {
-			const fullName = `${exchange}:${ticker}`;
-			return fullName === symbolName
-		});
+		}) => ticker === symbolName);
 		if (!symbolItem) {
 			console.log('[resolveSymbol]: Cannot resolve symbol', symbolName);
 			onResolveErrorCallback('cannot resolve symbol');

--- a/src/datafeed.js
+++ b/src/datafeed.js
@@ -50,7 +50,6 @@ async function getAllSymbols() {
 				const symbol = generateSymbol(exchange.value, leftPairPart, rightPairPart);
 				return {
 					symbol: symbol.short,
-					full_name: symbol.full,
 					description: symbol.short,
 					exchange: exchange.value,
 					type: 'crypto',
@@ -78,7 +77,8 @@ export default {
 		const symbols = await getAllSymbols();
 		const newSymbols = symbols.filter(symbol => {
 			const isExchangeValid = exchange === '' || symbol.exchange === exchange;
-			const isFullSymbolContainsInput = symbol.full_name
+			const fullName = `${symbol.exchange}:${symbol.symbol}`;
+			const isFullSymbolContainsInput = fullName
 				.toLowerCase()
 				.indexOf(userInput.toLowerCase()) !== -1;
 			return isExchangeValid && isFullSymbolContainsInput;
@@ -95,8 +95,12 @@ export default {
 		console.log('[resolveSymbol]: Method call', symbolName);
 		const symbols = await getAllSymbols();
 		const symbolItem = symbols.find(({
-			full_name,
-		}) => full_name === symbolName);
+			exchange,
+			symbol
+		}) => {
+			const fullName = `${exchange}:${symbol}`;
+			return fullName === symbolName
+		});
 		if (!symbolItem) {
 			console.log('[resolveSymbol]: Cannot resolve symbol', symbolName);
 			onResolveErrorCallback('cannot resolve symbol');
@@ -104,7 +108,7 @@ export default {
 		}
 		// Symbol information object
 		const symbolInfo = {
-			ticker: symbolItem.full_name,
+			ticker: symbolItem.symbol,
 			name: symbolItem.symbol,
 			description: symbolItem.description,
 			type: symbolItem.type,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -18,7 +18,6 @@ export function generateSymbol(exchange, fromSymbol, toSymbol) {
 	const short = `${fromSymbol}/${toSymbol}`;
 	return {
 		short,
-		full: `${exchange}:${short}`,
 	};
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -2,7 +2,7 @@
 import Datafeed from './datafeed.js';
 
 window.tvWidget = new TradingView.widget({
-	symbol: 'Bitfinex:BTC/USD',             // Default symbol
+	symbol: 'BTC/EUR',             // Default symbol
 	interval: '1D',                         // Default interval
 	fullscreen: true,                       // Displays the chart in the fullscreen mode
 	container: 'tv_chart_container',        // Reference to an attribute of the DOM element


### PR DESCRIPTION
Following work on CL-1851, this PR updates the tutorial to not depend on `full_name` from an external point of view.

**Not to be merged before releasing v28.**